### PR TITLE
fix(plainResponse): fix when question dont have badge and its needed

### DIFF
--- a/src/components/PlainResponse/index.js
+++ b/src/components/PlainResponse/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
 import {Row, Col} from 'react-bootstrap';
 
@@ -8,23 +8,39 @@ import {TextWithBadge} from '..';
 const PlainResponse = ({
     question, section
 }) => (
-    <Row>
-        <Col sm={6}>
-            {question.text && <TextWithBadge
-                question={question}
-            />}
-            {question.floatingLabel}
-        </Col>
-        <Col sm={6}>
-            {parseQuestion.parseQuestion(question, section)}
-            {question.textAfterInput && (
-                <span>
-                    {question.textAfterInput}
-                </span>)
-            }
-        </Col>
-    </Row>
+    <Fragment>
+        {question.extraBadge && (
+            <Row>
+                <Col sm={10}>
+                    <TextWithBadge
+                        question={{
+                            text: question.extraBadge.text,
+                            number: question.extraBadge.number,
+                            disabled: question.disabled
+                        }}
+                    />
+                </Col>
+            </Row>)
+        }
+        <Row>
+            <Col sm={6}>
+                {question.text && <TextWithBadge
+                    question={question}
+                />}
+                {question.floatingLabel}
+            </Col>
+            <Col sm={6}>
+                {parseQuestion.parseQuestion(question, section)}
+                {question.textAfterInput && (
+                    <span>
+                        {question.textAfterInput}
+                    </span>)
+                }
+            </Col>
+        </Row>
+    </Fragment>
 );
+
 
 PlainResponse.displayName = 'plainResponse';
 


### PR DESCRIPTION
Add option on question when the badge is required, its needed sometimes when the question have more then 1 question to show. and the second or third option don't have the real question instead have an information text with out number, so the question isn't drawed